### PR TITLE
fix(workflow): improve AI agent guidance for task display and action safety

### DIFF
--- a/app/services/workflow/tools/get_workflow_tasks_from_my_inbox.py
+++ b/app/services/workflow/tools/get_workflow_tasks_from_my_inbox.py
@@ -191,6 +191,7 @@ get_workflow_tasks_from_my_inbox_description="""
     Use format='json' for raw task data or format='table' (default) for formatted output.
     If you find markdown text in the result show it to the user.
     ALWAYS render the result as table if called with format='table' parameter
+    ALWAYS display task_title as the primary task identifier in all table and list output. Never use task_name, as it contains internal system codes that are not meaningful to end users.
 
     Make sure to use a request json object for the parameters.
     """

--- a/app/services/workflow/tools/task_action.py
+++ b/app/services/workflow/tools/task_action.py
@@ -1545,6 +1545,12 @@ task_action_description="""
     - Claim a task (assign it to yourself)
     - Complete a task (finish it) with required form property values collected via elicitation
     - Unclaim a task (release it if previously claimed)
+
+    CRITICAL: Never assume, infer, or present available task actions to the user 
+    without first calling this tool with action="complete" to retrieve the valid 
+    actions for that specific task. Actions vary by task type and workflow state 
+    and must always be read directly from the tool response before presenting 
+    options to the user.
     
     CRITICAL SAFETY RULE FOR action="complete":
     Do not create, invent, infer, assume, summarize, paraphrase, default, auto-fill, or guess any form_values yourself.


### PR DESCRIPTION
## Summary
This PR updates the tool descriptions for two workflow tools to improve AI agent behavior and user experience.

## Changes

### 1. get_workflow_tasks_from_my_inbox.py
Added instruction to always display `task_title` as the primary task identifier in table and list output, instead of `task_name` which contains internal system codes not meaningful to end users.

### 2. task_action.py
Added a critical rule requiring AI agents to always call this tool with `action="complete"` first to retrieve valid actions for a specific task before presenting options to the user. Actions vary by task type and must never be assumed.

## Note
File names `task_action.py` and `get_workflow_tasks_from_my_inbox.py` do not reflect the current tool names as renamed in v1.2.0. Consider renaming to `perform_workflow_task_action.py` and `get_my_workflow_inbox_tasks.py` for consistency.

## Testing
Validated against a live IBM watsonx Data Intelligence SaaS environment.